### PR TITLE
Feat/#478

### DIFF
--- a/src/pages/declaracoes/[id]/analise.tsx
+++ b/src/pages/declaracoes/[id]/analise.tsx
@@ -141,13 +141,22 @@ export default function DeclaracaoPage() {
                       {data.museologico?.status}
                     </span>
                   </span>
-                  <a
-                    href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/museologico`}
-                    className="mb-2"
-                  >
-                    <i className="fas fa-download" aria-hidden="true"></i>{" "}
-                    Baixar planilha
-                  </a>
+                  <div className="flex justify-end gap-4">
+                    <a
+                      href={`/api/public/declaracoes/download/analise/${data._id}/museologico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar comentários técnicos
+                    </a>
+                    <a
+                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/museologico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar planilha
+                    </a>
+                  </div>
                 </div>
                 {data.museologico.status !== "Recebida" && (
                   <Textarea
@@ -184,13 +193,22 @@ export default function DeclaracaoPage() {
                       {data.bibliografico?.status}
                     </span>
                   </span>
-                  <a
-                    href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/bibliografico`}
-                    className="mb-2"
-                  >
-                    <i className="fas fa-download" aria-hidden="true"></i>{" "}
-                    Baixar planilha
-                  </a>
+                  <div className="flex justify-end gap-4">
+                    <a
+                      href={`/api/public/declaracoes/download/analise/${data._id}/bibliografico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar comentários técnicos
+                    </a>
+                    <a
+                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/bibliografico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar planilha
+                    </a>
+                  </div>
                 </div>
                 {data.bibliografico.status !== "Recebida" && (
                   <Textarea
@@ -227,13 +245,22 @@ export default function DeclaracaoPage() {
                       {data.arquivistico?.status}
                     </span>
                   </span>
-                  <a
-                    href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/arquivistico`}
-                    className="mb-2"
-                  >
-                    <i className="fas fa-download" aria-hidden="true"></i>{" "}
-                    Baixar planilha
-                  </a>
+                  <div className="flex justify-end gap-4">
+                    <a
+                      href={`/api/public/declaracoes/download/analise/${data._id}/arquivistico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar comentários técnicos
+                    </a>
+                    <a
+                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/arquivistico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar planilha
+                    </a>
+                  </div>
                 </div>
                 {data.arquivistico.status !== "Recebida" && (
                   <Textarea

--- a/src/pages/declaracoes/[id]/index.tsx
+++ b/src/pages/declaracoes/[id]/index.tsx
@@ -294,13 +294,22 @@ export default function DeclaracaoPage() {
                       {data.museologico?.status}
                     </span>
                   </span>
-                  <a
-                    href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/museologico`}
-                    className="mb-2"
-                  >
-                    <i className="fas fa-download" aria-hidden="true"></i>{" "}
-                    Baixar planilha
-                  </a>
+                  <div className="grid grid-cols-2 gap-4">
+                    <a
+                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/museologico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar análise Ibram
+                    </a>
+                    <a
+                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/museologico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar planilha
+                    </a>
+                  </div>
                 </div>
                 <TableItens
                   acervo="museologico"
@@ -326,13 +335,22 @@ export default function DeclaracaoPage() {
                       {data.bibliografico?.status}
                     </span>
                   </span>
-                  <a
-                    href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/bibliografico`}
-                    className="mb-2"
-                  >
-                    <i className="fas fa-download" aria-hidden="true"></i>{" "}
-                    Baixar planilha
-                  </a>
+                  <div className="grid grid-cols-2 gap-4">
+                    <a
+                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/bibliografico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar análise Ibram
+                    </a>
+                    <a
+                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/bibliografico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar planilha
+                    </a>
+                  </div>
                 </div>
                 <TableItens
                   acervo="bibliografico"
@@ -358,13 +376,22 @@ export default function DeclaracaoPage() {
                       {data.arquivistico?.status}
                     </span>
                   </span>
-                  <a
-                    href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/arquivistico`}
-                    className="mb-2"
-                  >
-                    <i className="fas fa-download" aria-hidden="true"></i>{" "}
-                    Baixar planilha
-                  </a>
+                  <div className="grid grid-cols-2 gap-4">
+                    <a
+                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/arquivistico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar análise Ibram
+                    </a>
+                    <a
+                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/arquivistico`}
+                      className="mb-2"
+                    >
+                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                      Baixar planilha
+                    </a>
+                  </div>
                 </div>
                 <TableItens
                   acervo="arquivistico"

--- a/src/pages/declaracoes/[id]/index.tsx
+++ b/src/pages/declaracoes/[id]/index.tsx
@@ -294,22 +294,13 @@ export default function DeclaracaoPage() {
                       {data.museologico?.status}
                     </span>
                   </span>
-                  <div className="grid grid-cols-2 gap-4">
-                    <a
-                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/museologico`}
-                      className="mb-2"
-                    >
-                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
-                      Baixar análise Ibram
-                    </a>
-                    <a
-                      href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/museologico`}
-                      className="mb-2"
-                    >
-                      <i className="fas fa-download" aria-hidden="true"></i>{" "}
-                      Baixar planilha
-                    </a>
-                  </div>
+                  <a
+                    href={`/api/public/declaracoes/download/${data.museu_id._id}/${data.anoDeclaracao._id}/museologico`}
+                    className="mb-2"
+                  >
+                    <i className="fas fa-download" aria-hidden="true"></i>{" "}
+                    Baixar planilha
+                  </a>
                 </div>
                 <TableItens
                   acervo="museologico"


### PR DESCRIPTION
### Descrição:
- Adiciona botão para download na página de Parecer técnico nas abas dos tipos da declaração.

### Commit:
- 9ece7ffbb2a033a6e50eaf24ebd4753644c486cc0 (@thfields)
- b457809691ec19f1ca6a77c5239892e05c158bd6 (@thfields )

### Tarefa relacionada:
- [#478](https://tree.taiga.io/project/daltonmartins-inventario-nacional-de-bens-culturais-musealizados/task/478)[Frontend] Download do documento complementar de análise